### PR TITLE
CLOG-113 update <parent> version and Clog version to 11-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,7 +10,7 @@
   	<parent>
     	<artifactId>clog</artifactId>
     	<groupId>org.sakaiproject.clog</groupId>
-    	<version>0.9.5-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
   	
   	<packaging>jar</packaging>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -11,7 +11,7 @@
   	<parent>
     	<artifactId>clog</artifactId>
     	<groupId>org.sakaiproject.clog</groupId>
-    	<version>0.9.5-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
   	
   	<packaging>sakai-component</packaging>

--- a/help/pom.xml
+++ b/help/pom.xml
@@ -6,7 +6,7 @@
   	<parent>
     	<artifactId>clog</artifactId>
     	<groupId>org.sakaiproject.clog</groupId>
-    	<version>0.9.5-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
   	
   	<name>CLOG HELP</name>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -11,7 +11,7 @@
   	<parent>
     	<artifactId>clog</artifactId>
     	<groupId>org.sakaiproject.clog</groupId>
-    	<version>0.9.5-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
   
   	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
   	<name>CLOG</name>
   	<groupId>org.sakaiproject.clog</groupId>
   	<artifactId>clog</artifactId>
-  	<version>0.9.5-SNAPSHOT</version>
+  	<version>11-SNAPSHOT</version>
   	<packaging>pom</packaging>
 
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>master</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>11-SNAPSHOT</version>
         <relativePath>../master/pom.xml</relativePath>
     </parent>
 

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -10,7 +10,7 @@
   	<parent>
     	<artifactId>clog</artifactId>
     	<groupId>org.sakaiproject.clog</groupId>
-    	<version>0.9.5-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
   	
   	<packaging>war</packaging>


### PR DESCRIPTION
Adrian--pointing this PR at Clog master but before you consider merging it, I recommend creating a clog sakai-10 branch first.  I've also updated the version from 0.9.5-SNAPSHOT to 11-SNAPSHOT.  This aligns Clog master with Sakai trunk version practices.  However, if you would rather have clog master versioned 1.0.0-SNAPSHOT I'll happily adjust the PR.
