### PR TITLE
CLOG-152 Fix BlogWow Import

### DIFF
--- a/api/src/java/org/sakaiproject/clog/api/SakaiProxy.java
+++ b/api/src/java/org/sakaiproject/clog/api/SakaiProxy.java
@@ -28,6 +28,7 @@ import org.sakaiproject.memory.api.Cache;
 import org.sakaiproject.search.api.InvalidSearchQueryException;
 import org.sakaiproject.search.api.SearchResult;
 import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.ToolConfiguration;
 
 public interface SakaiProxy {
 
@@ -125,4 +126,8 @@ public interface SakaiProxy {
     public String getWysiwygEditor();
 
     public Cache getCache(String cache);
+
+    void addToolToToolConfig(ToolConfiguration tool);
+
+    boolean saveSite(Site site);
 }

--- a/impl/src/java/org/sakaiproject/clog/impl/ClogManagerImpl.java
+++ b/impl/src/java/org/sakaiproject/clog/impl/ClogManagerImpl.java
@@ -159,7 +159,7 @@ public class ClogManagerImpl implements ClogManager {
                     logger.debug("KEY: " + key);
                 }
 
-                if (!siteMap.containsKey(key)) {
+                if (siteMap != null && !siteMap.containsKey(key)) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Cache miss on '" + key + "'. It will be added.");
                     }
@@ -169,7 +169,11 @@ public class ClogManagerImpl implements ClogManager {
                         logger.debug("Cache hit on '" + key + "'");
                     }
                 }
-                return clogSecurityManager.filter((List<Post>) siteMap.get(key), query.getSiteId());
+                if (siteMap != null) {
+                    return clogSecurityManager.filter((List<Post>) siteMap.get(key), query.getSiteId());
+                } else {
+                    return clogSecurityManager.filter(persistenceManager.getPosts(query), null);
+                }
             }
         } else {
             return clogSecurityManager.filter(persistenceManager.getPosts(query), null);

--- a/impl/src/java/org/sakaiproject/clog/impl/SakaiProxyImpl.java
+++ b/impl/src/java/org/sakaiproject/clog/impl/SakaiProxyImpl.java
@@ -753,4 +753,27 @@ public class SakaiProxyImpl implements SakaiProxy {
             return null;
         }
     }
+
+    public void addToolToToolConfig(ToolConfiguration tool) {
+        tool.setTool("sakai.clog", toolManager.getTool("sakai.clog"));
+        tool.setTitle(toolManager.getTool("sakai.clog").getTitle());
+    }
+
+    public boolean saveSite(Site site) {
+        try {
+            Collection<Group> groups = site.getGroups();
+            for (Group g : groups) {
+                if (g.getTitle() == null || g.getTitle().trim().length() == 0) {
+                    g.setTitle("null");
+                }
+            }
+
+            siteService.save(site);
+            return true;
+        } catch (Exception e) {
+            logger.error("Error saving site: '" + site + "'.");
+            e.printStackTrace();
+            return false;
+        }
+    }
 }

--- a/impl/src/java/org/sakaiproject/clog/impl/sql/SQLGenerator.java
+++ b/impl/src/java/org/sakaiproject/clog/impl/sql/SQLGenerator.java
@@ -109,7 +109,7 @@ public class SQLGenerator implements ISQLGenerator {
             }
 
             if (query.queryByTitle()) {
-                statement.append(TITLE).append(" = '").append(query.getTitle()).append("' AND ");
+                statement.append(TITLE).append(" = '").append(query.getTitle().replace("'","''")).append("' AND ");
             }
 
             if (query.queryByCreator()) {


### PR DESCRIPTION
These changes fix the BlogWow import. They add the clog tool to a site
if the site does not have the clog tool (this is necessary as
a check is made to see if the tool is in the site later on).

Also adds in a couple workarounds for issues noticed when importing:
* Checks to see if a site's group's names are all present
* Also properly escapes ' in the title of posts