### PR TITLE
CLOG-116: MathJax is rendered in Clog tool only in the first load

### DIFF
--- a/tool/src/webapp/js/clog_utils.js
+++ b/tool/src/webapp/js/clog_utils.js
@@ -453,6 +453,7 @@ clog.utils = {
 
         this.decoratePost(post);
         this.renderTemplate('post', post, output);
+        if (typeof MathJax !== 'undefined') { MathJax.Hub.Queue(["Typeset",MathJax.Hub]); }
     },
     renderPageOfPosts: function (args) {
 


### PR DESCRIPTION
This new PR fixes an issue when the MathJax is disabled.