### PR TITLE
Escape Group Titles in bootstrap.jsp

### DIFF
--- a/tool/src/webapp/WEB-INF/bootstrap.jsp
+++ b/tool/src/webapp/WEB-INF/bootstrap.jsp
@@ -1,4 +1,5 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@taglib prefix="util" uri="http://example.com/functions" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html  
@@ -20,7 +21,7 @@
                 onPDAPortal:'${onPDAPortal}',
                 i18n: {},
                 groups: [
-                            <c:forEach items="${groups}" var="i" varStatus="is">{id: '${i.id}', title: '${i.title}', totalPosts: ${i.totalPosts}, lastPostDate: ${i.lastPostDate}}<c:if test="${not is.last}">,</c:if></c:forEach>
+                            <c:forEach items="${groups}" var="i" varStatus="is">{id: '${i.id}', title: '${util:escapeJS(i.title)}', totalPosts: ${i.totalPosts}, lastPostDate: ${i.lastPostDate}}<c:if test="${not is.last}">,</c:if></c:forEach>
                 ]
             };
         

--- a/tool/src/webapp/WEB-INF/functions.tld
+++ b/tool/src/webapp/WEB-INF/functions.tld
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright (c) 2017, University of Dayton
+  ~
+  ~ Licensed under the Educational Community License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~             http://opensource.org/licenses/ecl2
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<taglib
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
+        version="2.1">
+
+    <display-name>Custom Functions</display-name>
+    <tlib-version>1.0</tlib-version>
+    <short-name>util</short-name>
+    <uri>http://example.com/functions</uri>
+
+    <function>
+        <name>escapeJS</name>
+        <!--<function-class>org.apache.commons.lang3.StringEscapeUtils</function-class>-->
+        <!--<function-signature>java.lang.String escapeEcmaScript(java.lang.String)</function-signature>-->
+        <function-class>org.apache.commons.lang.StringEscapeUtils</function-class>
+        <function-signature>java.lang.String escapeJavaScript(java.lang.String)</function-signature>
+    </function>
+</taglib>


### PR DESCRIPTION
Group titles may have special characters in it which may brake the clog tool. This commit escapes the group title so that it is Javascript friendly.